### PR TITLE
Cleanup query parameters in url after login

### DIFF
--- a/template/src/configuration/setup/oauth.ts
+++ b/template/src/configuration/setup/oauth.ts
@@ -33,6 +33,15 @@ export const attemptInitialSignIn = async (userManager: UserManager) => {
             window.location.replace(`#/${initialRoute}`);
         }
 
+        // Remove oauth related query params. These are not needed after login and should not be shown
+        const queryParams = new URLSearchParams(window.location.search);
+        if (queryParams.has('code') || queryParams.has('state') || queryParams.has('session_state')) {
+            queryParams.delete('code');
+            queryParams.delete('state');
+            queryParams.delete('session_state');
+            window.location.search = queryParams.toString();
+        }
+
         routeStorage.discardRoute();
         return await Promise.resolve(user);
     } catch (error) {


### PR DESCRIPTION
When the user is redirected after they log in, the URL in the browser should not contain `code`, `state`, and `session_state` parameters. This PR aims to fix this by explicitly removing these parameters if they are present.